### PR TITLE
fix the link to the repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Tarik02/html-substring.git"
+    "url": "git+https://github.com/Tarik02/html-substring-js.git"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",


### PR DESCRIPTION
The link from https://www.npmjs.com/package/html-substring to the repository is incorrect